### PR TITLE
Abstraction of I2C interface for discussion - STM32

### DIFF
--- a/src/ArduinoInterface.h
+++ b/src/ArduinoInterface.h
@@ -21,6 +21,10 @@
 #include "Wire.h"
 #include "I2CInterface.h"
 
+/**
+ * The standard Ardiuno way of talking to I2C
+ * via the Wire.h library.
+ */
 class ArduinoInterface : public I2CInterface {
 public:
 

--- a/src/ArduinoInterface.h
+++ b/src/ArduinoInterface.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Bruce MacKinnon KC1FSZ
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _ArduinoInterface_h
+#define _ArduinoInterface_h
+
+#include "Arduino.h"
+#include "Wire.h"
+#include "I2CInterface.h"
+
+class ArduinoInterface : public I2CInterface {
+public:
+
+    ArduinoInterface() {
+        Wire.begin();
+    }
+
+    uint8_t check_address(uint8_t i2c_bus_addr) {
+    	Wire.beginTransmission(i2c_bus_addr);
+        return Wire.endTransmission();
+    }
+
+    uint8_t read(uint8_t i2c_bus_addr, uint8_t addr) {
+
+        uint8_t reg_val = 0;
+
+        Wire.beginTransmission(i2c_bus_addr);
+        Wire.write(addr);
+        Wire.endTransmission();
+
+        Wire.requestFrom(i2c_bus_addr, (uint8_t)1, (uint8_t)false);
+
+        while(Wire.available())
+        {
+            reg_val = Wire.read();
+        }
+
+        return reg_val;
+    }
+
+    uint8_t write(uint8_t i2c_bus_addr, uint8_t addr, uint8_t data) {
+    	Wire.beginTransmission(i2c_bus_addr);
+        Wire.write(addr);
+        Wire.write(data);
+        return Wire.endTransmission();
+    }
+
+    uint8_t write_bulk(uint8_t i2c_bus_addr, uint8_t addr, uint8_t bytes, uint8_t *data) {
+        Wire.beginTransmission(i2c_bus_addr);
+        Wire.write(addr);
+        for(int i = 0; i < bytes; i++)
+        {
+            Wire.write(data[i]);
+        }
+        return Wire.endTransmission();
+     }
+};
+
+#endif

--- a/src/I2CInterface.h
+++ b/src/I2CInterface.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Bruce MacKinnon KC1FSZ
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _I2CInterface_h
+#define _I2CInterface_h
+
+#include <stdint.h>
+
+/**
+ * A generic interface for interacting with an I2C bus
+ */
+class I2CInterface {
+public:
+    
+    /**
+     * Determmines whether a device is connected at the specified address.
+     */
+    virtual uint8_t check_address(uint8_t i2c_bus_addr) = 0;
+
+    /**
+     * Standard read operation.
+     */
+    virtual uint8_t read(uint8_t i2c_bus_addr, uint8_t addr) = 0;
+
+    /** 
+     * Standard write operation.
+     */
+    virtual uint8_t write(uint8_t i2c_bus_addr, uint8_t addr, uint8_t data) = 0;
+
+    /**
+     * Multi-byte write operation
+     */
+    virtual uint8_t write_bulk(uint8_t i2c_bus_addr, uint8_t addr, uint8_t bytes, uint8_t *data) = 0;
+};
+
+#endif

--- a/src/STM32_HAL_Interface.h
+++ b/src/STM32_HAL_Interface.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Bruce MacKinnon KC1FSZ
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _STM32_HAL_Interface_h
+#define _STM32_HAL_Interface_h
+
+#include <stdint.h>
+#include "I2CInterface.h"
+
+// An STM32/HAL based implementation of the I2CInterface.
+// 
+// NOT IMPLEMENTED YET!!
+//
+class STM32_HAL_Interface : public I2C_Interface {
+public:
+    // TODO: WILL PASS THE HAL I2C STRUCTURE HERE
+    STM32_HAL_Interface() {
+    }
+    uint8_t check_address(uint8_t i2c_bus_addr) {
+        return 0;
+    }
+    uint8_t read(uint8_t i2c_bus_addr, uint8_t addr) {
+        return 0;
+    }
+    uint8_t write(uint8_t i2c_bus_addr, uint8_t addr, uint8_t data) {
+        return 0;
+    }
+    uint8_t write_bulk(uint8_t i2c_bus_addr, uint8_t addr, uint8_t bytes, uint8_t *data)  {
+        return 0;
+    }
+};
+
+#endif

--- a/src/si5351.cpp
+++ b/src/si5351.cpp
@@ -24,7 +24,9 @@
 
 #include <stdint.h>
 
-// Bring in the relevant interface to the I2C bus
+// Bring in the relevant interface to the I2C bus.  This has been 
+// abstracted to allow the library to be used in differnet 
+// hardware environments.
 #ifndef STM32
 #include "STM32_HAL_Interface.h"
 static STM32_HAL_Interface I2C_Interface_Instance;

--- a/src/si5351.cpp
+++ b/src/si5351.cpp
@@ -24,10 +24,18 @@
 
 #include <stdint.h>
 
+// Bring in the relevant interface to the I2C bus
+#ifndef STM32
+#include "STM32_HAL_Interface.h"
+static STM32_HAL_Interface I2C_Interface_Instance;
+#else
 #include "Arduino.h"
 #include "Wire.h"
-#include "si5351.h"
+#include "ArduinoInterface.h"
+static ArduinoInterface I2C_Interface_Instance;
+#endif
 
+#include "si5351.h"
 
 /********************/
 /* Public functions */
@@ -36,6 +44,9 @@
 Si5351::Si5351(uint8_t i2c_addr):
 	i2c_bus_addr(i2c_addr)
 {
+	// Connect to the appropriate I2C interface
+	i2c_interface = &I2C_Interface_Instance;
+	
 	xtal_freq[0] = SI5351_XTAL_FREQ;
 
 	// Start by using XO ref osc as default for each PLL
@@ -62,13 +73,8 @@ Si5351::Si5351(uint8_t i2c_addr):
  */
 bool Si5351::init(uint8_t xtal_load_c, uint32_t xo_freq, int32_t corr)
 {
-	// Start I2C comms
-	Wire.begin();
-
 	// Check for a device on the bus, bail out if it is not there
-	Wire.beginTransmission(i2c_bus_addr);
-	uint8_t reg_val;
-  reg_val = Wire.endTransmission();
+	uint8_t reg_val = i2c_interface->check_address(i2c_bus_addr);
 
 	if(reg_val == 0)
 	{
@@ -565,7 +571,7 @@ void Si5351::set_pll(uint64_t pll_freq, enum si5351_pll target_pll)
 		pllb_freq = pll_freq;
   }
 
-  delete params;
+  delete [] params;
 }
 
 /*
@@ -672,7 +678,7 @@ void Si5351::set_ms(enum si5351_clock clk, struct Si5351RegSet ms_reg, uint8_t i
 			break;
 	}
 
-	delete params;
+	delete [] params;
 }
 
 /*
@@ -1240,7 +1246,7 @@ void Si5351::set_vcxo(uint64_t pll_freq, uint8_t ppm)
 	// Write the parameters
 	si5351_write_bulk(SI5351_PLLB_PARAMETERS, i, params);
 
-	delete params;
+	delete [] params;
 
 	// Write the VCXO parameters
 	vcxo_param = ((vcxo_param * ppm * SI5351_VCXO_MARGIN) / 100ULL) / 1000000ULL;
@@ -1309,40 +1315,17 @@ void Si5351::set_ref_freq(uint32_t ref_freq, enum si5351_pll_input ref_osc)
 
 uint8_t Si5351::si5351_write_bulk(uint8_t addr, uint8_t bytes, uint8_t *data)
 {
-	Wire.beginTransmission(i2c_bus_addr);
-	Wire.write(addr);
-	for(int i = 0; i < bytes; i++)
-	{
-		Wire.write(data[i]);
-	}
-	return Wire.endTransmission();
-
+	return i2c_interface->write_bulk(i2c_bus_addr, addr, bytes, data);
 }
 
 uint8_t Si5351::si5351_write(uint8_t addr, uint8_t data)
 {
-	Wire.beginTransmission(i2c_bus_addr);
-	Wire.write(addr);
-	Wire.write(data);
-	return Wire.endTransmission();
+	return i2c_interface->write(i2c_bus_addr, addr, data);
 }
 
 uint8_t Si5351::si5351_read(uint8_t addr)
 {
-	uint8_t reg_val = 0;
-
-	Wire.beginTransmission(i2c_bus_addr);
-	Wire.write(addr);
-	Wire.endTransmission();
-
-	Wire.requestFrom(i2c_bus_addr, (uint8_t)1, (uint8_t)false);
-
-	while(Wire.available())
-	{
-		reg_val = Wire.read();
-	}
-
-	return reg_val;
+	return i2c_interface->read(i2c_bus_addr, addr);
 }
 
 /*********************/

--- a/src/si5351.h
+++ b/src/si5351.h
@@ -329,6 +329,7 @@ private:
   uint8_t clkin_div;
   uint8_t i2c_bus_addr;
   bool clk_first_set[8];
+	// This is a connection to the I2C bus
 	I2CInterface* i2c_interface;
 };
 

--- a/src/si5351.h
+++ b/src/si5351.h
@@ -29,9 +29,8 @@
 #ifndef SI5351_H_
 #define SI5351_H_
 
-#include "Arduino.h"
-#include "Wire.h"
 #include <stdint.h>
+#include "I2CInterface.h"
 
 /* Define definitions */
 
@@ -330,6 +329,7 @@ private:
   uint8_t clkin_div;
   uint8_t i2c_bus_addr;
   bool clk_first_set[8];
+	I2CInterface* i2c_interface;
 };
 
 #endif /* SI5351_H_ */


### PR DESCRIPTION
Hi Jason:
Thanks for an excellent Si5351 library.  I use it all the time on Arduino/Teensy.  I've stated doing some projects using the STM32 family and I'd love to be able to keep using your library.  I think this should be straight-forward if the I2C interface can be abstracted a bit.  This pull request is a request for comment on the general idea.

The IC2Interface class provides the generic interface to the I2C bus.  There would be implementations of this interface for different platforms.  The default would be Arduino to make sure existing code doesn't break.

Let me know if you'd be open to accepting this general type of change.  If so, I'll do some testing and provide the complete implementation.

73s, Bruce KC1FSZ