### PR TITLE
Fix three allocation related compiler warnings

### DIFF
--- a/src/si5351.cpp
+++ b/src/si5351.cpp
@@ -565,7 +565,7 @@ void Si5351::set_pll(uint64_t pll_freq, enum si5351_pll target_pll)
 		pllb_freq = pll_freq;
   }
 
-  delete params;
+  delete[] params;
 }
 
 /*
@@ -672,7 +672,7 @@ void Si5351::set_ms(enum si5351_clock clk, struct Si5351RegSet ms_reg, uint8_t i
 			break;
 	}
 
-	delete params;
+	delete[] params;
 }
 
 /*
@@ -1240,7 +1240,7 @@ void Si5351::set_vcxo(uint64_t pll_freq, uint8_t ppm)
 	// Write the parameters
 	si5351_write_bulk(SI5351_PLLB_PARAMETERS, i, params);
 
-	delete params;
+	delete[] params;
 
 	// Write the VCXO parameters
 	vcxo_param = ((vcxo_param * ppm * SI5351_VCXO_MARGIN) / 100ULL) / 1000000ULL;


### PR DESCRIPTION
Without this PR, I see the following warnings when compilation this library:

```
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp: In member function 'void Si5351::set_pll(uint64_t, si5351_pll)':
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp:568:10: warning: 'void operator delete(void*, std::size_t)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  568 |   delete params;
      |          ^~~~~~
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp:522:35: note: returned from 'void* operator new [](std::size_t)'
  522 |   uint8_t *params = new uint8_t[20];
      |                                   ^
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp: In member function 'void Si5351::set_vcxo(uint64_t, uint8_t)':
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp:1243:16: warning: 'void operator delete(void*, std::size_t)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
 1243 |         delete params;
      |                ^~~~~~
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp:1206:41: note: returned from 'void* operator new [](std::size_t)'
 1206 |         uint8_t *params = new uint8_t[20];
      |                                         ^
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp: In member function 'void Si5351::set_ms(si5351_clock, Si5351RegSet, uint8_t, uint8_t, uint8_t)':
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp:675:16: warning: 'void operator delete(void*, std::size_t)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  675 |         delete params;
      |                ^~~~~~
Arduino/libraries/Etherkit_Si5351/src/si5351.cpp:586:41: note: returned from 'void* operator new [](std::size_t)'
  586 |         uint8_t *params = new uint8_t[20];
```

The changes in this PR fix these compiler warnings. 

Thanks for your time, and attention.